### PR TITLE
Fixed the error view layout issue

### DIFF
--- a/src/ServiceBusExplorer.UI/ConnectDialog.axaml
+++ b/src/ServiceBusExplorer.UI/ConnectDialog.axaml
@@ -7,7 +7,7 @@
         Width="550" Height="380"
         WindowStartupLocation="CenterOwner">
 
-    <Grid Margin="20" RowDefinitions="*,Auto,Auto">
+    <Grid Margin="20" RowDefinitions="Auto,*,Auto">
         <!-- Tab Control for Authentication Methods -->
         <TabControl Grid.Row="0" SelectedIndex="{Binding SelectedAuthTabIndex}">
 
@@ -60,7 +60,7 @@
 
         </TabControl>
 
-        <!-- Error message (shown below tabs) -->
+        <!-- Error message (shown below tabs, fills remaining space) -->
         <Border Grid.Row="1"
                 Background="#FFFFCC"
                 Padding="8,4"
@@ -69,9 +69,12 @@
                 CornerRadius="4"
                 Margin="0,8,0,16"
                 IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-            <TextBlock Text="{Binding ErrorMessage}"
-                       Foreground="#CC0000"
-                       TextWrapping="Wrap" />
+            <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <TextBlock Text="{Binding ErrorMessage}"
+                           Foreground="#CC0000"
+                           TextWrapping="Wrap" />
+            </ScrollViewer>
         </Border>
 
         <!-- Buttons -->


### PR DESCRIPTION
## Description

The connection dialog would get completly skewed by an error text view when error happened during the connection.

With this PR, I ensure that the error view occupies only the remaining space, and it increases in size when the dialog size increases, also, it's placed inside a scroll view so that the content of the error scrolls if it can not fit the area.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests pass (`dotnet test`)
- [ ] Manual testing on Windows
- [ ] Manual testing on macOS
- [x] Manual testing on Linux

**Test Configuration**:
* OS:
* .NET Version:
* Service Bus Configuration:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if appropriate):

Before the fix
<img width="1261" height="956" alt="before_fix" src="https://github.com/user-attachments/assets/a0408bdc-f06f-4105-9063-1da36ae7e8de" />

After the fix
<img width="1550" height="1180" alt="after_fix" src="https://github.com/user-attachments/assets/7469e724-a36f-4d93-a8b1-9f6af15e7fe4" />



