### PR TITLE
fix: Prevent Unicode escape sequences in JSON message display

### DIFF
--- a/src/ServiceBusExplorer.UI/ViewModels/EditMessageDialogViewModel.cs
+++ b/src/ServiceBusExplorer.UI/ViewModels/EditMessageDialogViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Xml.Linq;
 using Avalonia.Controls;
@@ -48,9 +49,10 @@ public partial class EditMessageDialogViewModel(Window window) : ObservableObjec
         try
         {
             var jsonDoc = JsonDocument.Parse(MessageBody);
-            MessageBody = JsonSerializer.Serialize(jsonDoc, new JsonSerializerOptions 
-            { 
-                WriteIndented = true 
+            MessageBody = JsonSerializer.Serialize(jsonDoc, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             });
         }
         catch (Exception ex)

--- a/src/ServiceBusExplorer.UI/ViewModels/MessageListViewModel.cs
+++ b/src/ServiceBusExplorer.UI/ViewModels/MessageListViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -488,7 +489,8 @@ public partial class MessageListViewModel : ObservableObject
             var jsonDoc = JsonDocument.Parse(SelectedMessage.Body);
             var formattedJson = JsonSerializer.Serialize(jsonDoc.RootElement, new JsonSerializerOptions
             {
-                WriteIndented = true
+                WriteIndented = true,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             });
             
             // Create a new MessageViewModel with formatted body
@@ -555,7 +557,8 @@ public partial class MessageListViewModel : ObservableObject
             var jsonDoc = JsonDocument.Parse(value.Body);
             FormattedMessageBody = JsonSerializer.Serialize(jsonDoc.RootElement, new JsonSerializerOptions
             {
-                WriteIndented = true
+                WriteIndented = true,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             });
         }
         catch (JsonException)

--- a/src/ServiceBusExplorer.UI/ViewModels/SendMessageDialogViewModel.cs
+++ b/src/ServiceBusExplorer.UI/ViewModels/SendMessageDialogViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Xml;
@@ -99,7 +100,8 @@ public partial class SendMessageDialogViewModel : ObservableObject
                     var jsonDoc = JsonDocument.Parse(MessageBody);
                     MessageBody = JsonSerializer.Serialize(jsonDoc.RootElement, new JsonSerializerOptions
                     {
-                        WriteIndented = true
+                        WriteIndented = true,
+                        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
                     });
                     ErrorMessage = null;
                     break;


### PR DESCRIPTION
Add JavaScriptEncoder.UnsafeRelaxedJsonEscaping to JsonSerializerOptions to display Japanese and other non-ASCII characters properly instead of showing escape sequences like \u822A\u8CB4.

Modified files:
- MessageListViewModel.cs: Fix display in message detail panel
- EditMessageDialogViewModel.cs: Fix display in edit dialog
- SendMessageDialogViewModel.cs: Fix display in send dialog

## Description

Please include a summary of the changes and which issue is fixed. Include relevant motivation and context.

Fixes https://github.com/haga0531/service-bus-explorer/issues/8

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests pass (`dotnet test`)
- [x] Manual testing on Windows
- [x] Manual testing on macOS
- [ ] Manual testing on Linux

**Test Configuration**:
* OS:
* .NET Version:
* Service Bus Configuration:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if appropriate):