### PR TITLE
fix: Remove duplicate CloseRequested handler in ResubmitConfirmDialog

### DIFF
--- a/src/ServiceBusExplorer.UI/ResubmitConfirmDialog.axaml.cs
+++ b/src/ServiceBusExplorer.UI/ResubmitConfirmDialog.axaml.cs
@@ -7,27 +7,5 @@ public partial class ResubmitConfirmDialog : Window
     public ResubmitConfirmDialog()
     {
         InitializeComponent();
-        
-        // Subscribe to view model events when DataContext is set
-        DataContextChanged += OnDataContextChanged;
-    }
-    
-    private void OnDataContextChanged(object? sender, System.EventArgs e)
-    {
-        if (DataContext is ResubmitConfirmDialogViewModel vm)
-        {
-            vm.CloseRequested += OnCloseRequested;
-        }
-    }
-    
-    private void OnCloseRequested(object? sender, (bool confirmed, bool deleteFromDeadLetter) result)
-    {
-        if (DataContext is ResubmitConfirmDialogViewModel vm)
-        {
-            vm.CloseRequested -= OnCloseRequested;
-        }
-        
-        // For bulk operations, we only care about confirmed/cancelled
-        Close(result.confirmed);
     }
 }


### PR DESCRIPTION
Fixed a bug where clicking the "Resubmit" button in the resubmit confirmation dialog showed "Message resubmit cancelled by user" even though the user clicked confirm.

##  Root cause
The ResubmitConfirmDialog.axaml.cs code-behind had a duplicate CloseRequested event handler that called Close() before MessageListViewModel's handler could capture the confirmed value. This was
  inconsistent with other dialogs (DeleteConfirmDialog, PurgeConfirmDialog) which don't have this extra handler.

Fix ~ Removed the duplicate event handler from ResubmitConfirmDialog.axaml.cs, making it consistent with other confirmation dialogs.

##  Type of change

- Bug fix (non-breaking change which fixes an issue)

##  Screenshots (if appropriate):
  N/A - This is a behavioral fix with no UI changes.