### PR TITLE
feat: add azure CLI auth

### DIFF
--- a/src/ServiceBusExplorer.Core/NamespaceService.cs
+++ b/src/ServiceBusExplorer.Core/NamespaceService.cs
@@ -1,5 +1,4 @@
-﻿using Azure.Messaging.ServiceBus.Administration;
-using ServiceBusExplorer.Core.Models;
+﻿using ServiceBusExplorer.Core.Models;
 using ServiceBusExplorer.Infrastructure;
 using ServiceBusExplorer.Infrastructure.Models;
 

--- a/src/ServiceBusExplorer.Tests/UI/Models/MessageViewModelTests.cs
+++ b/src/ServiceBusExplorer.Tests/UI/Models/MessageViewModelTests.cs
@@ -1,7 +1,7 @@
 #nullable disable
+using System.ComponentModel;
 using FluentAssertions;
 using ServiceBusExplorer.UI.Models;
-using System.ComponentModel;
 
 namespace ServiceBusExplorer.Tests.UI.Models;
 

--- a/src/ServiceBusExplorer.UI/ConnectDialog.axaml
+++ b/src/ServiceBusExplorer.UI/ConnectDialog.axaml
@@ -63,7 +63,7 @@
                                 FontSize="11"
                                 Foreground="#2196F3"
                                 TextWrapping="Wrap"
-                                 Margin="0,8,0,0" />
+                                Margin="0,8,0,0" />
                  </Grid>
              </TabItem>
 

--- a/src/ServiceBusExplorer.UI/ConnectDialog.axaml
+++ b/src/ServiceBusExplorer.UI/ConnectDialog.axaml
@@ -33,30 +33,39 @@
                 </Grid>
             </TabItem>
 
-            <!-- Tab 2: Azure Credentials -->
-            <TabItem Header="Azure Credentials">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,*" Margin="0,16,0,0">
-                    <TextBlock Grid.Row="0"
-                               Text="Service Bus Namespace:"
-                               Margin="0,0,0,8" />
-                    <TextBox Grid.Row="1"
-                             Text="{Binding Namespace}"
-                             Watermark="myservicebus.servicebus.windows.net"
-                             Margin="0,0,0,8"
-                             IsEnabled="{Binding !IsConnecting}" />
-                    <TextBlock Grid.Row="2"
-                               Text="Full namespace URL (without https://)"
-                               FontSize="11"
-                               Foreground="Gray"
-                               Margin="0,0,0,8" />
-                    <TextBlock Grid.Row="3"
-                               Text="A browser window will open for Azure authentication when you connect."
-                               FontSize="11"
-                               Foreground="#2196F3"
-                               TextWrapping="Wrap"
-                               Margin="0,8,0,0" />
-                </Grid>
-            </TabItem>
+             <!-- Tab 2: Azure Credentials -->
+             <TabItem Header="Azure Credentials">
+                 <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*" Margin="0,16,0,0">
+                     <TextBlock Grid.Row="0"
+                                Text="Service Bus Namespace:"
+                                Margin="0,0,0,8" />
+                     <TextBox Grid.Row="1"
+                              Text="{Binding Namespace}"
+                              Watermark="myservicebus.servicebus.windows.net"
+                              Margin="0,0,0,8"
+                              IsEnabled="{Binding !IsConnecting}" />
+                     <TextBlock Grid.Row="2"
+                                Text="Full namespace URL (without https://)"
+                                FontSize="11"
+                                Foreground="Gray"
+                                Margin="0,0,0,8" />
+                     <TextBlock Grid.Row="3"
+                                Text="Authentication Method:"
+                                Margin="0,8,0,8" />
+                     <ComboBox Grid.Row="4"
+                               SelectedIndex="{Binding SelectedCredentialMethodIndex}"
+                               IsEnabled="{Binding !IsConnecting}">
+                         <ComboBoxItem Content="Azure CLI (az login)" />
+                         <ComboBoxItem Content="Interactive Browser" />
+                     </ComboBox>
+                     <TextBlock Grid.Row="5"
+                                Text="Azure CLI requires Azure CLI installed and you must run 'az login' first. Interactive Browser will open a browser window."
+                                FontSize="11"
+                                Foreground="#2196F3"
+                                TextWrapping="Wrap"
+                                 Margin="0,8,0,0" />
+                 </Grid>
+             </TabItem>
 
         </TabControl>
 

--- a/src/ServiceBusExplorer.UI/ViewModels/ConnectDialogViewModel.cs
+++ b/src/ServiceBusExplorer.UI/ViewModels/ConnectDialogViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Core;
 using Azure.Identity;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -22,6 +23,7 @@ public partial class ConnectDialogViewModel : ObservableObject
 
     // Azure Credentials tab
     [ObservableProperty] private string? @namespace;
+    [ObservableProperty] private int selectedCredentialMethodIndex = 0;
 
     // Shared state
     [ObservableProperty] private bool isConnecting = false;
@@ -69,28 +71,30 @@ public partial class ConnectDialogViewModel : ObservableObject
                     return;
                 }
 
-                // Validate namespace format
-                if (!Namespace.EndsWith(".servicebus.windows.net", StringComparison.OrdinalIgnoreCase))
-                {
-                    ErrorMessage = "Namespace must be in format: myservicebus.servicebus.windows.net";
-                    return;
-                }
+                 // Validate namespace format
+                 if (!Namespace.EndsWith(".servicebus.windows.net", StringComparison.OrdinalIgnoreCase))
+                 {
+                     ErrorMessage = "Namespace must be in format: myservicebus.servicebus.windows.net";
+                     return;
+                 }
 
-                // Create Interactive Browser Credential
-                // This will open a browser window for authentication
-                try
-                {
-                    var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
-                    {
-                        TenantId = "common", // Allow any tenant (work, school, or personal accounts)
-                        ClientId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46", // Azure CLI client ID (well-known, safe to use)
-                        RedirectUri = new Uri("http://localhost") // Standard OAuth redirect for desktop apps
-                    });
+                 try
+                 {
+                     TokenCredential credential = SelectedCredentialMethodIndex switch
+                     {
+                         0 => new AzureCliCredential(),
+                         _ => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
+                         {
+                             TenantId = "common", // Allow any tenant (work, school, or personal accounts)
+                             ClientId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46", // Azure CLI client ID (well-known, safe to use)
+                             RedirectUri = new Uri("http://localhost") // Standard OAuth redirect for desktop apps
+                         })
+                     };
 
-                    authContext = new TokenCredentialAuthContext(Namespace, credential);
-                }
-                catch (Exception ex)
-                {
+                     authContext = new TokenCredentialAuthContext(Namespace, credential);
+                 }
+                 catch (Exception ex)
+                 {
                     ErrorMessage = $"Failed to create credential: {ex.Message}";
                     return;
                 }

--- a/src/ServiceBusExplorer.UI/ViewModels/ConnectDialogViewModel.cs
+++ b/src/ServiceBusExplorer.UI/ViewModels/ConnectDialogViewModel.cs
@@ -72,7 +72,7 @@ public partial class ConnectDialogViewModel : ObservableObject
                 }
 
                  // Validate namespace format
-                 if (!Namespace.EndsWith(".servicebus.windows.net", StringComparison.OrdinalIgnoreCase))
+                 if (!Namespace.Trim().EndsWith(".servicebus.windows.net", StringComparison.OrdinalIgnoreCase))
                  {
                      ErrorMessage = "Namespace must be in format: myservicebus.servicebus.windows.net";
                      return;

--- a/src/ServiceBusExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/ServiceBusExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-using Azure.Messaging.ServiceBus.Administration;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ServiceBusExplorer.Core;


### PR DESCRIPTION
## Description

This PR adds the possibility to use an existing AzureCLI auth instance to login to the service bus explorer.

The UI looks like this:
<img width="1394" height="920" alt="image" src="https://github.com/user-attachments/assets/fbc2de41-6a9a-43dc-abd7-8245484fdbdd" />


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests pass (`dotnet test`)
- [ ] Manual testing on Windows
- [x] Manual testing on macOS
- [ ] Manual testing on Linux

**Test Configuration**:
* OS: MacOS
* .NET Version: dotn
* Service Bus Configuration:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if appropriate):