### PR TITLE
bugfix/handle-bulk-resubmit-confirmation-and-pass-delete-DL-flag-around

### DIFF
--- a/src/ServiceBusExplorer.Infrastructure/IMessageResubmitProvider.cs
+++ b/src/ServiceBusExplorer.Infrastructure/IMessageResubmitProvider.cs
@@ -9,5 +9,6 @@ public interface IMessageResubmitProvider : IAsyncDisposable
         string queueOrTopic,
         string messageId,
         string? subscription = null,
+        bool deleteFromDeadLetter = true,
         CancellationToken cancellationToken = default);
 }

--- a/src/ServiceBusExplorer.Tests/Core/MessageServiceTests.cs
+++ b/src/ServiceBusExplorer.Tests/Core/MessageServiceTests.cs
@@ -218,7 +218,7 @@ public class MessageServiceTests
         await _sut.ResubmitDeadLetterMessageAsync(_authContext, queueName, messageId);
 
         // Assert
-        _mockResubmitProvider.Verify(x => x.ResubmitMessageAsync(queueName, messageId, null, It.IsAny<CancellationToken>()), Times.Once);
+        _mockResubmitProvider.Verify(x => x.ResubmitMessageAsync(queueName, messageId, null, true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -233,7 +233,20 @@ public class MessageServiceTests
         await _sut.ResubmitDeadLetterMessageAsync(_authContext, topicName, messageId, subscriptionName);
 
         // Assert
-        _mockResubmitProvider.Verify(x => x.ResubmitMessageAsync(topicName, messageId, subscriptionName, It.IsAny<CancellationToken>()), Times.Once);
+        _mockResubmitProvider.Verify(x => x.ResubmitMessageAsync(topicName, messageId, subscriptionName, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ResubmitDeadLetterMessageAsync_WhenNotDeleting_ShouldPassFlagToProvider()
+    {
+        // Arrange
+        const string messageId = "msg123";
+        const string queueName = "queue1";
+
+        // Act
+        await _sut.ResubmitDeadLetterMessageAsync(_authContext, queueName, messageId, deleteFromDeadLetter: false);
+
+        // Assert
+        _mockResubmitProvider.Verify(x => x.ResubmitMessageAsync(queueName, messageId, null, false, It.IsAny<CancellationToken>()), Times.Once);
     }
 }
-


### PR DESCRIPTION
## Description

Previously resubmitting messages in bulk was not working. The confirmation dialog was opened, but never closed and executed. 

This was because the close handler was missing. Also the delete from DLs checkbox information was not passed to the related provider to actually purge the messages afterwards.

Both issues are fixed with this PR.

Fixes #20 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- Resubmit 2 messages in bulk with delete DLs
- Resubmit 2 messages in bulk without delete DLs

- [x] Unit tests pass (`dotnet test`)
- [ ] Manual testing on Windows
- [x] Manual testing on macOS
- [ ] Manual testing on Linux

**Test Configuration**:
* OS: macOS
* .NET Version: dotnet 8
* Service Bus Configuration: ?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published